### PR TITLE
Fixing typo in 'difference' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ layout: default
         </ul>
         <p class="lead">
           Overall this gives AEON something closer to a Litecoin model in terms of sharing more code with the upstream project
-          while maintaining an indepednent identity and leadership, along with some new and experimental features,
+          while maintaining an independent identity and leadership, along with some new and experimental features,
           which will continue to be sustainable going forward.<br/>
           Thus everyone can have a high degree of confidence that AEON will continue to be maintained and remain usable.
         </p>


### PR DESCRIPTION
simple typo fix in website