### PR TITLE
Small header/footer edits

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -69,13 +69,13 @@
           <div class="col-md-8 col-sm-8">
             <h1><strong>AEON</strong> isn't a cryptocurrency.<br/><strong>It's a lifestyle.</strong></h1>
             <p class="lead"><strong>It's about polished perfection, attained by breaking the rules with calculated mastery of the art.<strong></p>
-            <p class="lead">It's about respecting history and pushing innovation forward at the same time. It's about more than just math: it's a vision of a world where luxury is the same as entry-level, and the limits are the heavens themselves. <small>&copy; americanpegasus</small></p>
+            <p class="lead">It's about respecting history and pushing innovation forward at the same time. It's about more than just math: it's a vision of a world where luxury is the same as entry-level, and the limits are the heavens themselves.</p>
             <ul class="banner-list">
               <li><i class="fa fa-check"></i>PoW algorithm: CryptoNight-Lite</li>
               <li><i class="fa fa-check"></i>Max supply: ~18.4 million</li>
-              <li><i class="fa fa-check"></i>Block reward: Smoothly varying</li>
+              <li><i class="fa fa-check"></i>Block reward: smoothly varying</li>
               <li><i class="fa fa-check"></i>Block time: 240 seconds</li>
-              <li><i class="fa fa-check"></i>Difficulty: Retargets at every block</li>
+              <li><i class="fa fa-check"></i>Difficulty: retargets at every block</li>
             </ul>
           </div>
           <div class="col-lg-4 col-md-4 col-sm-5 hidden-sm hidden-xs">
@@ -95,8 +95,8 @@
         <!-- Footer Intro  -->
         <div class="col-md-4">
           <h3>About this Project</h3>
-          <p>It is open source and completely free to use without restrictions.</p>
-          <p>Anyone is able to contribute to AEON.</p>
+          <p>AEON is open source and completely free to use without restriction.</p>
+          <p>Likewise, everybody is free to contribute.</p>
         </div>
         <!-- End Footer Intro -->
 
@@ -105,7 +105,6 @@
           <h3>Exchanges</h3>
           <ul class="quick-links">
             <li><a href="https://bittrex.com/Market/Index?MarketName=BTC-AEON" rel="nofollow">Bittrex</a></li>
-            <li><a href="https://www.cryptopia.co.nz/Exchange/?market=AEON_BTC" rel="nofollow">Cryptopia</a></li>
           </ul>
         </div>
         <!-- End Exchanges -->
@@ -150,7 +149,7 @@
     <div class="container">
       <div class="row">
         <div class="col-lg-6 col-sm-6">
-          <p>Copyright &copy; 2016-&infin;, AEON, The Monero Project.</p>
+          <p>Copyright &copy; 2017-&infin;, AEON, The Monero Project.</p>
         </div>
         <div class="col-lg-6 col-sm-6">
           <p class="copyright">Made with <i class="icon-heart"></i> in crypto space</p>


### PR DESCRIPTION
Removed American Pegasus attribution to header. I celebrate AP just as much as anybody, but having his name in the header of AEON's homepage will only confuse visitors who don't know who he is or that having his name there is attributing the copy to him.

Removed Cryptopia exchange, since they discontinued it.

Updated copyright to 2017