### PR TITLE
Updated site title and meta description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,9 +13,8 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: "AEON - 2nd gen cryptonote, anonymous, mobile-friendly, scalable, pruning"
-keywords: "AEON, cryptocurrency, privacy, fungibility, anonymous cryptocurrency, cryptonote"
-description: "AEON is an anonymous cryptocurrency. Lightweight untraceable blockchain."
+title: "AEON - a mobile-friendly private digital currency"
+description: "Based on CryptoNote, AEON is a private digital currency with lightweight features like blockchain pruning. Come check out Monero's little brother!"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://example.com" # the base hostname & protocol for your site
 


### PR DESCRIPTION
The main point of the title and meta description is copy for search engines. Here's the current title/description as seen on Google:

![screen shot 2017-04-05 at 6 00 58 pm](https://cloud.githubusercontent.com/assets/21302237/24728902/e9181f80-1a29-11e7-8262-45d5d95149d5.png)

The title runs off the page (too many characters) and the description is short and halting in tone.

This PR suggests a new title/description:

![screen shot 2017-04-05 at 6 14 06 pm](https://cloud.githubusercontent.com/assets/21302237/24729336/b895adf8-1a2b-11e7-8136-d69527136ab0.png)

Also, this PR removes meta-keywords, which is best practice as seen in this Yoast.com article: https://yoast.com/meta-keywords/