### PR TITLE
Improved header copy

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,9 +67,9 @@
       <div class="container">
         <div class="row">
           <div class="col-md-8 col-sm-8">
-            <h1><strong>AEON</strong> isn't a cryptocurrency.<br/><strong>It's a lifestyle.</strong></h1>
-            <p class="lead"><strong>It's about polished perfection, attained by breaking the rules with calculated mastery of the art.<strong></p>
-            <p class="lead">It's about respecting history and pushing innovation forward at the same time. It's about more than just math: it's a vision of a world where luxury is the same as entry-level, and the limits are the heavens themselves.</p>
+            <h1><strong>AEON</strong> isn't just a currency.<br/><strong>It's a lifestyle.</strong></h1>
+            <p class="lead">Decentralized digital currency is slowly becoming a normal part of everday life. Yet everybody's main internet device continues to be their cellphone, a device with a low-powered CPU and limited available storage.</p>
+            <p class="lead">AEON is about enabling this era, enabling an age where all people everywhere have the freedom to privately send and receive money with whatever gadget they already own.</p>
             <ul class="banner-list">
               <li><i class="fa fa-check"></i>PoW algorithm: CryptoNight-Lite</li>
               <li><i class="fa fa-check"></i>Max supply: ~18.4 million</li>


### PR DESCRIPTION
As seen in issue #2, the current header of Aeon.cash uses language that is over the top, and even American Pegasus himself, the author, suggested the words should be changed.

This PR suggests a new line body of copy for the header that still plays off the original idea. Since AEON is about mobile devices, it sort of imagines an **age/era/aeon** where everybody is transacting privately (CryptoNote) but with their phones.

New header (click to expand):

![screen shot 2017-04-05 at 10 45 01 pm](https://cloud.githubusercontent.com/assets/21302237/24735933/41da51fa-1a53-11e7-8d38-2976272b493f.png)

Hopefully this feels a lot less pumpy and yet communicates a vision to somebody interacting with AEON for the first time.

Note: I did edit some CSS to make the screenshot look that good. I can make those CSS edits in a future PR. Also note that the words in the actual commit differ slightly from the screenshot.