### PR TITLE
Center-align the Features section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -616,7 +616,7 @@ Features
 
 .features {
     margin-bottom: 40px;
-    text-align: left;
+    text-align: center;
 }
 .features i {
     float: left;


### PR DESCRIPTION
I'm proposing that the three features (Secure/Private/Untraceable) be center-aligned rather than left-aligned. Really the tradeoff is one of legibility versus flow. While the left alignment's firm edge makes the somewhat technical text easier to read (and thus, comprehend), it looks abrupt and awkward beneath a center aligned headline (A lightweight CryptoNote digital currency). So I think center aligning the entire section is probably best.