### PR TITLE
add AeonBlocks to list of block explorers

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -114,6 +114,7 @@
         <div class="col-md-2">
           <h3>Block explorers</h3>
           <ul class="quick-links">
+            <li><a href="https://aeonblocks.com/" rel="nofollow">AeonBlocks</a></li>
             <li><a href="https://chainradar.com/aeon/blocks" rel="nofollow">ChainRadar</a></li>
             <li><a href="https://minergate.com/blockchain/aeon/blocks" rel="nofollow">MinerGate</a></li>
           </ul>


### PR DESCRIPTION
[ChainRadar](https://chainradar.com/aeon/blocks) and [MinerGate](https://minergate.com/blockchain/aeon/blocks) are not working, at least at the moment.
So I added [AeonBlocks](https://aeonblocks.com/) on top of the list.

Before:
![1](https://user-images.githubusercontent.com/39473497/42777603-e6c2547c-893a-11e8-9a9a-46df9abfdcd1.jpg)

After:
![2](https://user-images.githubusercontent.com/39473497/42777607-edfb9988-893a-11e8-9285-fd52ac2ff21a.jpg)
