### PR TITLE
update latest release to v0.12.3.0 and add mac os x & linux to downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,14 +90,22 @@ layout: default
       <div class="row">
         <div class="col-md-12 headline">
           <h2>Download AEON</h2>
-          <p><em>Latest release:</em> Sophia (0.12.0.0) - <a href="https://github.com/aeonix/aeon/releases/tag/v0.12.0.0">Release notes</a></p>
+          <p><em>Latest release:</em> Sophia (0.12.5.0) - <a href="https://github.com/aeonix/aeon/releases/tag/v0.12.5.0-aeon">Release notes</a></p>
         </div>
       </div>
     <div class="row">
       <div class="col-lg-12 col-md-6">
-        <div class="features col-lg-3 col-md-6 text-center col-lg-offset-3">
+        <div class="features col-lg-3 col-md-6 text-center">
           <i class="line-font blue fa fa-windows"></i>
-          <h3><a href="https://github.com/aeonix/aeon/releases">Windows 64-bit</a></h3>
+          <h3><a href="https://github.com/aeonix/aeon/releases/download/v0.12.5.0-aeon/aeon-win-x64-v0.12.5.0.zip">Windows, 64-bit</a></h3>
+        </div>
+        <div class="features col-lg-3 col-md-6 text-center">
+          <i class="line-font blue fa fa-apple"></i>
+          <h3><a href="https://github.com/aeonix/aeon/releases/download/v0.12.5.0-aeon/aeon-mac-x64-v0.12.5.0.tar.bz2">Mac OS X, 64-bit</a></h3>
+        </div>
+        <div class="features col-lg-3 col-md-6 text-center">
+          <i class="line-font blue fa fa-linux"></i>
+          <h3><a href="https://github.com/aeonix/aeon/releases/download/v0.12.5.0-aeon/aeon-linux-x64-v0.12.5.0.tar.bz2">Linux, 64-bit</a></h3>
         </div>
         <div class="features col-lg-3 col-md-6 text-center">
           <i class="line-font blue fa fa-github"></i>


### PR DESCRIPTION
I'm not sure if this is needed, but I think it looks a bit better than the windows only icon/link.

feedback is welcome.

**PREVIEW (Desktop)**
![1](https://user-images.githubusercontent.com/39473497/42777996-05d0f2a0-893c-11e8-8c34-da2777446cdf.png)

**PREVIEW (Mobile)**
![2](https://user-images.githubusercontent.com/39473497/42778008-0cea8326-893c-11e8-9e33-7ff37916de2e.png)


