### PR TITLE
replace social buttons with links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,7 +93,7 @@
     <div class="container">
       <div class="row">
         <!-- Footer Intro  -->
-        <div class="col-md-3">
+        <div class="col-md-4">
           <h3>About this project</h3>
           <p>AEON is open source and completely free to use without restriction.</p>
           <p>Likewise, everybody is welcome to contribute.</p>
@@ -131,24 +131,15 @@
         <!-- End Quick links -->
 
         <!-- Social Links -->
-        <div class="col-sm-3">
+        <div class="col-md-2">
           <h3>AEON links</h3>
-          <ul class="social">
-            <li class="facebook">
-              <a href="https://bitcointalk.org/index.php?topic=641696.0" rel="nofollow"><i class="fa fa-bitcoin"></i></a>
-            </li>
-            <li class="twitter">
-              <a href="https://twitter.com/AeonCoin" rel="nofollow"><i class="fa fa-twitter"></i></a>
-            </li>
-            <li class="reddit">
-              <a href="https://www.reddit.com/r/aeon" rel="nofollow"><i class="fa fa-reddit"></i></a>
-            </li>
-            <li class="stack-exchange">
-              <a href="https://monero.stackexchange.com" rel="nofollow"><i class="fa fa-stack-exchange"></i></a>
-            </li>
-            <li class="wiki">
-              <a href="https://aeon.wiki" rel="nofollow"><i class="fa fa-wikipedia-w"></i></a>
-            </li>
+          <ul class="quick-links">
+            <li><a href="https://bitcointalk.org/index.php?topic=641696.0" rel="nofollow" target="_blank">BitcoinTalk</a></li>
+            <li><a href="https://twitter.com/AeonCoin" rel="nofollow" target="_blank">Twitter</a></li>
+            <li><a href="https://www.reddit.com/r/aeon" rel="nofollow" target="_blank">Reddit</a></li>
+            <li><a href="https://monero.stackexchange.com" rel="nofollow" target="_blank">StackExchange</a></li>
+            <li><a href="https://aeon.wiki" rel="nofollow" target="_blank">Aeon.Wiki</a></li>
+            <li><a href="https://github.com/aeonix" rel="nofollow" target="_blank">Github</a></li>
           </ul>
         </div>
         <!--End Social Links -->


### PR DESCRIPTION
I had trouble to identify the symbols/links especially on mobile where you do not see the url on mouse over.
the buttons were also only clickable on the icon and not on the whole button.

I also added a link to [github aeonix account](https://github.com/aeonix).
I didn't remove css stlying [Social Links](https://github.com/aeon1234/aeonix.github.io/blob/9dfb88b3f4904f7828b817b3bdef7d2d5b1d0dfd/css/style.css#L1059).

feedback is welcome.

**BEFORE:**
![1](https://user-images.githubusercontent.com/39473497/42778262-d4841d52-893c-11e8-89bb-95c550838784.png)

**AFTER:**
![2](https://user-images.githubusercontent.com/39473497/42778287-e824a99e-893c-11e8-8b56-c68d89faf98d.png)
