### PR TITLE
Remove abandoned block explorers and add an Exchange

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -106,6 +106,7 @@
           <ul class="quick-links">
             <li><a href="https://bittrex.com/Market/Index?MarketName=BTC-AEON" rel="nofollow">Bittrex</a></li>
             <li><a href="https://hitbtc.com/exchange/AEON-to-BTC" rel="nofollow">HitBTC</a></li>
+            <li><a href="https://tradeogre.com/exchange/BTC-AEON" rel="nofollow">TradeOgre</a></li>
           </ul>
         </div>
         <!-- End Exchanges -->
@@ -115,8 +116,6 @@
           <h3>Block explorers</h3>
           <ul class="quick-links">
             <li><a href="https://aeonblocks.com/" rel="nofollow">AeonBlocks</a></li>
-            <li><a href="https://chainradar.com/aeon/blocks" rel="nofollow">ChainRadar</a></li>
-            <li><a href="https://minergate.com/blockchain/aeon/blocks" rel="nofollow">MinerGate</a></li>
           </ul>
         </div>
         <!-- End Block explorers -->


### PR DESCRIPTION
Chainradar and Minergate block explorers are abandoned since last hardfork (2 months ago). Also added TradeOgre Exchange to the list because it has more Aeon 24h volume than HitBTC.