### PR TITLE
fix typo GitHub in footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -147,7 +147,7 @@
               <li><a href="https://www.reddit.com/r/aeon" rel="nofollow" target="_blank">Reddit</a></li>
               <li><a href="https://monero.stackexchange.com" rel="nofollow" target="_blank">StackExchange</a></li>
               <li><a href="https://aeon.wiki" rel="nofollow" target="_blank">Aeon.Wiki</a></li>
-              <li><a href="https://github.com/aeonix" rel="nofollow" target="_blank">Github</a></li>
+              <li><a href="https://github.com/aeonix" rel="nofollow" target="_blank">GitHub</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
before `Github`
after `GitHub`