### PR TITLE
rename funding system link in navbar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
               <li><a href="#difference">Difference</a></li>
               <li><a href="#downloads">Download</a></li>
               <li><a href="#presskit">Press Kit</a></li>
-              <li><a href="https://www.aeonfunding.com">Aeon Funding</a></li>
+              <li><a href="https://www.aeonfunding.com">Funding System</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
I think it should be named `Funding System` instead of `Aeon Funding`.
I had changed some things in #43 and then this error happened, the preview picture also shows `Funding System`. Sorry for this mess.