### PR TITLE
Add BISQ network order book to exchanges

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -121,6 +121,7 @@
               <li><a href="https://changenow.io/?from=btc&to=aeon&amount=0.01" rel="nofollow">ChangeNOW</a> [aeon/any]</li>
               <li><a href="https://simpleswap.io" rel="nofollow">SimpleSwap</a> [aeon/any]</li>
               <li><a href="https://Xchange.me" rel="nofollow">Xchange</a> [any->aeon]</li>
+              <li><a href="https://bisq.network/markets/?currency=aeon_btc" rel="nofollow">Bisq</a> [aeon<=>btc]</li>
             </ul>
           </div>
           <br>


### PR DESCRIPTION
Add link to the Bisq markets page for aeon/btc trading pair. Actual trading is done on the bisq platform available here: https://bisq.network and selecting a specific OS. Aeon is not currently on the download release 9.1 on their website but is available if built from source: https://github.com/bisq-network/bisq and will be included in their next release 9.2 as the code has been merged.