### PR TITLE
Replace non functioning aeon.wiki

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -152,7 +152,7 @@
               <li><a href="https://twitter.com/AeonCoin" rel="nofollow" target="_blank">Twitter</a></li>
               <li><a href="https://www.reddit.com/r/aeon" rel="nofollow" target="_blank">Reddit</a></li>
               <li><a href="https://monero.stackexchange.com" rel="nofollow" target="_blank">StackExchange</a></li>
-              <li><a href="https://aeon.wiki" rel="nofollow" target="_blank">Aeon.Wiki</a></li>
+              <li><a href="https://coinwik.org/Aeon" rel="nofollow" target="_blank">Aeon Wiki</a></li>
               <li><a href="https://github.com/aeonix" rel="nofollow" target="_blank">GitHub</a></li>
               <li><a href="https://webchat.freenode.net/?channels=%23aeon" rel="nofollow" target="_blank">IRC</a></li>
               <li><a href="https://discord.gg/xWZ2z78" rel="nofollow" target="_blank">Discord</a></li>


### PR DESCRIPTION
https://aeon.wiki is no longer a maintained or functioning website. Replacing with next best wiki source for Aeon with https://coinwik.org/Aeon.