### PR TITLE
update exchange pairs to include common swap symbol

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -112,15 +112,17 @@
           <div>
             <h3>Exchanges</h3>
             <ul class="quick-links">
-              <li><a href="https://bittrex.com/Market/Index?MarketName=BTC-AEON" rel="nofollow">Bittrex</a> [aeon/btc]</li>
-              <li><a href="https://hitbtc.com/exchange/AEON-to-BTC" rel="nofollow">HitBTC</a> [aeon/btc]</li>
-              <li><a href="https://tradeogre.com/exchange/BTC-AEON" rel="nofollow">TradeOgre</a> [aeon/btc]</li>
-              <li><a href="https://bitliber.com/markets/aeon-btc" rel="nofollow">Bitliber</a> [aeon/btc]</li>
-              <li><a href="https://bitliber.com/markets/aeon-xmr" rel="nofollow">Bitliber</a> [aeon/xmr]</li>
-              <li><a href="https://letsdocoinz.com/AEON-BTC" rel="nofollow">LetsDoCoinz</a> [aeon/btc]</li>
-              <li><a href="https://changenow.io/?from=btc&to=aeon&amount=0.01" rel="nofollow">ChangeNOW</a> [aeon/any]</li>
-              <li><a href="https://simpleswap.io" rel="nofollow">SimpleSwap</a> [aeon/any]</li>
-              <li><a href="https://Xchange.me" rel="nofollow">Xchange</a> [any->aeon]</li>
+              <li><a href="https://bittrex.com/Market/Index?MarketName=BTC-AEON" rel="nofollow">Bittrex</a> [aeon<=>btc]</li>
+              <li><a href="https://hitbtc.com/exchange/AEON-to-BTC" rel="nofollow">HitBTC</a> [aeon<=>btc]</li>
+              <li><a href="https://tradeogre.com/exchange/BTC-AEON" rel="nofollow">TradeOgre</a> [aeon<=>btc]</li>
+              <li><a href="https://bitliber.com/markets/aeon-btc" rel="nofollow">Bitliber</a> [aeon<=>btc]</li>
+              <li><a href="https://bitliber.com/markets/aeon-xmr" rel="nofollow">Bitliber</a> [aeon<=>xmr]</li>
+              <li><a href="https://letsdocoinz.com/AEON-BTC" rel="nofollow">LetsDoCoinz</a> [aeon<=>btc]</li>
+              <li><a href="https://changenow.io/?from=btc&to=aeon&amount=0.01" rel="nofollow">ChangeNOW</a> [aeon<=>any]</li>
+              <li><a href="https://simpleswap.io" rel="nofollow">SimpleSwap</a> [aeon<=>any]</li>
+              <li><a href="https://Xchange.me" rel="nofollow">Xchange.me</a> [any=>aeon]</li>
+              <li><a href="https://bisq.network/markets/?currency=aeon_btc" rel="nofollow">Bisq</a> [aeon<=>btc]</li>
+              <li><a href="https://aeonapi.com" rel="nofollow">AeonAPI</a> [aeon=>btc]</li>
             </ul>
           </div>
           <br>
@@ -152,7 +154,7 @@
               <li><a href="https://twitter.com/AeonCoin" rel="nofollow" target="_blank">Twitter</a></li>
               <li><a href="https://www.reddit.com/r/aeon" rel="nofollow" target="_blank">Reddit</a></li>
               <li><a href="https://monero.stackexchange.com" rel="nofollow" target="_blank">StackExchange</a></li>
-              <li><a href="https://aeon.wiki" rel="nofollow" target="_blank">Aeon.Wiki</a></li>
+              <li><a href="https://coinwik.org/Aeon" rel="nofollow" target="_blank">Aeon Wiki</a></li>
               <li><a href="https://github.com/aeonix" rel="nofollow" target="_blank">GitHub</a></li>
               <li><a href="https://webchat.freenode.net/?channels=%23aeon" rel="nofollow" target="_blank">IRC</a></li>
               <li><a href="https://discord.gg/xWZ2z78" rel="nofollow" target="_blank">Discord</a></li>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ layout: default
     <div class="row">
       <div class="col-md-12 headline">
         <h2>Download AEON</h2>
-        <p><em>Latest release:</em> <a href="https://github.com/aeonix/aeon/releases/tag/v0.12.6.0-aeon">Sophia (0.12.6.0)</a></p>
+        <p><em>Latest release:</em> <a href="https://github.com/aeonix/aeon/releases/tag/v0.12.8.0-aeon">Sophia (0.12.8.0)</a></p>
       </div>
     </div>
     <div class="row">
@@ -96,22 +96,22 @@ layout: default
         <h3>
           <span class="fa fa-windows">&nbsp;&nbsp;Windows, 64-bit</span>
         </h3>
-        <a href="https://github.com/aeonix/aeon-gui/releases/download/v0.12.6.0-aeon/aeon-gui-win-x64-v0.12.6.0.zip">Windows, 64-bit</a><br>
-        <a href="https://github.com/aeonix/aeon/releases/download/v0.12.6.0-aeon/aeon-win-x64-v0.12.6.0.zip">Windows, 64-bit Command-Line Tools Only</a><br><br>
+        <a href="https://github.com/aeonix/aeon-gui/releases/download/v0.12.8.0-aeon/aeon-gui-win-x64-v0.12.8.0.zip">Windows, 64-bit</a><br>
+        <a href="https://github.com/aeonix/aeon/releases/download/v0.12.8.0-aeon/aeon-win-x64-v0.12.8.0.zip">Windows, 64-bit Command-Line Tools Only</a><br><br>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-5 text-center">
         <h3>
           <span class="fa fa-apple">&nbsp;&nbsp;Mac OS X, 64-bit</span>
         </h3>
-        <a href="https://github.com/aeonix/aeon-gui/releases/download/v0.12.6.0-aeon/aeon-gui-mac-x64-v0.12.6.0.tar.bz2">Mac OS X, 64-bit</a><br>
-        <a href="https://github.com/aeonix/aeon/releases/download/v0.12.6.0-aeon/aeon-mac-x64-v0.12.6.0.tar.bz2">Mac OS X, 64-bit Command-Line Tools Only</a><br><br>
+        <a href="https://github.com/aeonix/aeon-gui/releases/download/v0.12.8.0-aeon/aeon-gui-mac-x64-v0.12.8.0.tar.bz2">Mac OS X, 64-bit</a><br>
+        <a href="https://github.com/aeonix/aeon/releases/download/v0.12.8.0-aeon/aeon-mac-x64-v0.12.8.0.tar.bz2">Mac OS X, 64-bit Command-Line Tools Only</a><br><br>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-5 col-md-offset-1 text-center">
         <h3>
           <span class="fa fa-linux">&nbsp;&nbsp;Linux, 64-bit</span>
         </h3>
-        <a href="https://github.com/aeonix/aeon-gui/releases/download/v0.12.6.0-aeon/aeon-gui-linux-x64-v0.12.6.0.tar.bz2">Linux, 64-bit</a><br>
-        <a href="https://github.com/aeonix/aeon/releases/download/v0.12.6.0-aeon/aeon-linux-x64-v0.12.6.0.tar.bz2">Linux, 64-bit Command-Line Tools Only</a><br><br>
+        <a href="https://github.com/aeonix/aeon-gui/releases/download/v0.12.8.0-aeon/aeon-gui-linux-x64-v0.12.8.0.tar.bz2">Linux, 64-bit</a><br>
+        <a href="https://github.com/aeonix/aeon/releases/download/v0.12.8.0-aeon/aeon-linux-x64-v0.12.8.0.tar.bz2">Linux, 64-bit Command-Line Tools Only</a><br><br>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-5 text-center">
         <h3>


### PR DESCRIPTION
Prior we used aeon/btc or aeon->btc, then started adding aeon<=>any. This commit is to just centralize the symbol used so they all look the same. For example: Using Aeon=>BTC for an Aeon to BTC only transaction allowed, using BTC=>Aeon when a BTC to Aeon only transaction allowed, or when multiple exchange currencies allowed using Aeon<=>Any. 

Also adding in AeonAPI for our Aeon to BTC payment processor.