### PR TITLE
update block explorer list

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -128,8 +128,9 @@
           <div>
             <h3>Block explorers</h3>
             <ul class="quick-links">
-              <li><a href="https://aeonblocks.com/" rel="nofollow">AeonBlocks</a></li>
               <li><a href="http://162.210.173.150" rel="nofollow">162.210.173.150</a> / <a href="http://www.aeon.lol" rel="nofollow">aeon.lol</a></li>
+              <li><a href="https://aeonblockexplorer.com/" rel="nofollow">AEONBlockExplorer.com</a></li>
+              <li><a href="https://aeonstats.com/" rel="nofollow">AEONStats.com</a></li>
             </ul>
           </div>
           <br>


### PR DESCRIPTION
Removes aeonblocks.com as block explorer is behind > 19 days as of this commit.
Adds AEONBlockExplorer.com - courtesy of camthegeek.
Adds AEONStats.com - courtesy of 420Coupe.