### PR TITLE
update branding aeon logo to its links with correct dimensions

### DIFF
--- a/_includes/content.html
+++ b/_includes/content.html
@@ -162,8 +162,8 @@
       <div class="features col-sm-4 col-md-3 col-md-offset-1 text-center">
         <img src="/branding/aeon_logo_32x32.png"><br>
         <a href="/branding/aeon_logo_16x16.png">PNG 16x16</a><br>
-        <a href="/branding/aeon_logo_32x32.png">PNG 128x128</a><br>
-        <a href="/branding/aeon_logo_64x64.png">PNG 500x500</a><br>
+        <a href="/branding/aeon_logo_128x128.png">PNG 128x128</a><br>
+        <a href="/branding/aeon_logo_500x500.png">PNG 500x500</a><br>
         <a href="/branding/aeon_logo.svg">SVG</a>
       </div>
       <div class="features col-sm-4 col-md-4 text-center">


### PR DESCRIPTION
thanks to `ZerOOCooL` in discord to inform us there about this issue.

two links of aeon logo in branding section showed other dimensions than they were linked to.