### PR TITLE
remove negligent exchanges

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,9 +23,6 @@
               <li><a href="https://bittrex.com/Market/Index?MarketName=BTC-AEON" rel="nofollow">Bittrex</a> [aeon&#x21D4;btc]</li>
               <li><a href="https://tradeogre.com/exchange/BTC-AEON" rel="nofollow">TradeOgre</a> [aeon&#x21D4;btc]</li>
               <li><a href="https://hitbtc.com/exchange/AEON-to-BTC" rel="nofollow">HitBTC</a> [aeon&#x21D4;btc]</li>
-              <li><a href="https://www.altilly.com/market/AEON_BTC" rel="nofollow">Altilly</a> [aeon&#x21D4;btc]</li>
-              <li><a href="https://aeon.to" rel="nofollow">AEON.to</a> [aeon&#x21D2;btc]</li>
-              <li><a href="https://Xchange.me" rel="nofollow">Xchange</a> [any&#x21D2;aeon]</li>
               <li><a href="https://bisq.network/markets/?currency=aeon_btc" rel="nofollow">Bisq</a> [aeon&#x21D4;btc]</li>
             </ul>
           </div>


### PR DESCRIPTION
remove exchanges that no longer support Aeon: Altilly, Aeon.to, Xchange.me