### PR TITLE
footer: update exchanges

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,10 +22,7 @@
           <div>
             <h3>{{ site.data.i18n.content.footer.column2.heading1[page.lang] }}</h3>
             <ul class="quick-links">
-              <li><a href="https://bittrex.com/Market/Index?MarketName=BTC-AEON" rel="nofollow">Bittrex</a> [aeon&#x21D4;btc]</li>
               <li><a href="https://tradeogre.com/exchange/BTC-AEON" rel="nofollow">TradeOgre</a> [aeon&#x21D4;btc]</li>
-              <li><a href="https://hitbtc.com/exchange/AEON-to-BTC" rel="nofollow">HitBTC</a> [aeon&#x21D4;btc]</li>
-              <li><a href="https://bisq.network/markets/?currency=aeon_btc" rel="nofollow">Bisq</a> [aeon&#x21D4;btc]</li>
             </ul>
           </div>
           <br>


### PR DESCRIPTION
removed:
- [bittrex](https://bittrex.com/Market/Index?MarketName=BTC-AEON) (delisted)
- [bisq](https://bisq.network/markets/?currency=aeon_btc) (delisted)
- [hitbtc]() (prices seem off, also no longer listed under aeon markets on [coinmarketcap](https://coinmarketcap.com/currencies/aeon/markets))