### PR TITLE
footer: update block explorers

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,8 +33,7 @@
             <h3>{{ site.data.i18n.content.footer.column2.heading2[page.lang] }}</h3>
             <ul class="quick-links">
               <li><a href="http://104.168.163.221" rel="nofollow">104.168.163.221</a></li>
-              <li><a href="https://aeonblockexplorer.com" rel="nofollow">AEONBlockExplorer.com</a></li>
-              <li><a href="http://209.126.84.37:8081" rel="nofollow">aeonblockchecker.ninja</a></li>
+              <li><a href="http://209.126.84.37:8081" rel="nofollow">209.126.84.37:8081</a></li>
               <li><a href="https://aeonstats.com" rel="nofollow">aeonstats.com</a></li>
               <li><a href="https://aeonstats.info" rel="nofollow">aeonstats.info</a></li>
             </ul>


### PR DESCRIPTION
#130 

removed:
- [aeonblockexplorer.com](https://aeonblockexplorer.com) (still not working)

renamed:
- [aeonblockchecker.ninja](http://209.126.84.37:8081) to [209.126.84.37:8081](http://209.126.84.37:8081)  (domain not working anymore, paging @BigslimVdub)