### PR TITLE
Downloads.html: update hashes for v0.14.2.1

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -105,20 +105,14 @@ layout: default
                 </h3>
               </div>
               <div class="col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
-<pre>SHA256(aeon-gui-linux-x64-v0.14.1.0.tar.bz2)= fe4d98e46211a72a618a4a14669796fd570829a4dddb830c33cb20bec7d414f2
-SHA256(aeon-gui-mac-x64-v0.14.1.0.tar.bz2)= bf77694df5bfe3ccd9262db14355094161d31990bba0a5b26dd99a36d9036c64
-SHA256(aeon-gui-win-x64-v0.14.1.0.zip)= d8b384be827c841dfe40e8037f5b11ec7c024ebe4bd65f45d01ed81fce8baf0d
-SHA256(aeon-linux-x64-v0.14.1.0.tar.bz2)= 15d5b01d0d9434bce70b088315086dd83ff9dea20a5492ffccc6d1e3704cc1f5
-SHA256(aeon-mac-x64-v0.14.1.0.tar.bz2)= d9cc9fc393db5993190a3fe40c88f2047feb4c0a692b1b704deec108ad3d454a
-SHA256(aeon-win-x64-v0.14.1.0.zip)= 7d289940ed7e79e6f929feea122a889066e9fc1be06fd22d0e7801a8b31b1e5f
+<pre>SHA256(aeon-gui-linux-x64-v0.14.2.1.tar.bz2)= 058592cf0464e5971b6f3e9955783a9e30234c121eef9d5bf0479b5c8806a2ae
+SHA256(aeon-gui-mac-x64-v0.14.2.1.tar.bz2)= 1bca53f1c35293df969f7ec2ff2be315588daa7b1ba7e5c92b90db296a6a38f9
+SHA256(aeon-gui-win-x64-v0.14.2.1.zip)= ce421c9ea93507d25d0e4ecdeebe16af9840128a581c10402c4f0722be379b57
+SHA256(aeon-linux-x64-v0.14.2.1.tar.bz2)= ab629361308dd3a7bd5737d73ae4920d49d6b5e01098bb1001ce91837f686a0f
+SHA256(aeon-mac-x64-v0.14.2.1.tar.bz2)= 1bae7848f06ce7ac3fc2e04bf70cd9469bf6e691f9ec979f25beb7c6d6bb9ba3
+SHA256(aeon-win-x64-v0.14.2.1.zip)= 599b5567b350976286e3ecefe922b2dbfcef3e577b0819ff9fd67ce844409b0a
 SHA256(aeon-blockchain-1265000.raw)= 3be0b4bd6d118b8fdbef056aacde4303a07b8dc204aa6c7787cf5f043953649c
 </pre>
-              </div>
-              <div class="col-xs-12 text-center">
-                <p>
-                  <a href="/hashes.asc">{{ site.data.i18n.content.download.pgpSignature[page.lang] }}</a>
-                  (<a href="https://raw.githubusercontent.com/aeonix/aeon/master/utils/gpg_keys/stoffu.asc">{{ site.data.i18n.content.download.signingKey[page.lang] }}</a>)
-                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Updated hashes for the most recent binaries and removed link to PGP signed hashes. An updated PGP signed hashes file for v0.14.2.1 is a welcome future addition :)